### PR TITLE
Option and result

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,6 +3,7 @@ lastix_add_library(
     "lastix/core/box.hpp"
     "lastix/core/diagnostics.hpp"
     "lastix/core/diagnostics.cpp"
+    "lastix/core/option.hpp"
 )
 
 target_include_directories(

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,7 @@ lastix_add_library(
     "lastix/core/diagnostics.hpp"
     "lastix/core/diagnostics.cpp"
     "lastix/core/option.hpp"
+    "lastix/core/result.hpp"
 )
 
 target_include_directories(

--- a/core/lastix/core/option.hpp
+++ b/core/lastix/core/option.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "lastix/core/diagnostics.hpp"
+
+#include <optional>
+
+namespace lx::core {
+
+    using NoneType = std::nullopt_t;
+    static constexpr auto None = std::nullopt;
+
+    template <class T> class Some {
+
+        public:
+            explicit Some(T value) noexcept : _value(std::move(value)) {
+            }
+
+            // template <class... Args>
+            // explicit Some(Args&&... args) noexcept
+            //     : _value(std::forward<Args>(args)...) {
+            // }
+
+            auto operator*() & noexcept -> T& {
+                return _value;
+            }
+
+            auto operator*() const& noexcept -> const T& {
+                return _value;
+            }
+
+            auto operator*() && noexcept -> T&& {
+                return std::move(_value);
+            }
+
+        private:
+            T _value;
+    };
+
+    template <class U> Some(Some<U> s) -> Some<Some<U>>;
+
+    template <class T> class Option {
+
+        public:
+            Option(NoneType) : _value(None) {
+            }
+
+            Option(Some<T> some) : _value(*std::move(some)) {
+            }
+
+            template <class U>
+            requires std::convertible_to<U, T>
+            Option(Some<U> some) : _value(*std::move(some)) {
+            }
+
+            [[nodiscard]] auto is_some() const noexcept -> bool {
+                return _value.has_value();
+            }
+
+            [[nodiscard]] auto is_none() const noexcept -> bool {
+                return !this->is_some();
+            }
+
+            auto unwrap() & noexcept -> T& {
+                if (!_value) [[unlikely]]
+                    panic("Called unwrap() on None");
+
+                return *_value;
+            }
+
+            auto unwrap() const& noexcept -> const T& {
+                if (!_value) [[unlikely]]
+                    panic("Called unwrap() on None");
+
+                return *_value;
+            }
+
+            auto unwrap() && noexcept -> T&& {
+                if (!_value) [[unlikely]]
+                    panic("Called unwrap() on None");
+
+                return std::move(*_value);
+            }
+
+            auto expect(std::string_view msg) & noexcept -> T& {
+                if (!_value) [[unlikely]]
+                    panic(msg);
+
+                return *_value;
+            }
+
+            auto expect(std::string_view msg) const& noexcept -> const T& {
+                if (!_value) [[unlikely]]
+                    panic(msg);
+
+                return *_value;
+            }
+
+            auto expect(std::string_view msg) && noexcept -> T&& {
+                if (!_value) [[unlikely]]
+                    panic(msg);
+
+                return std::move(*_value);
+            }
+
+            auto swap(Option& other) noexcept -> void {
+                std::swap(_value, other._value);
+            }
+
+            operator bool() const noexcept {
+                return this->is_some();
+            }
+
+        private:
+            std::optional<T> _value;
+    };
+
+}; // namespace lx::core

--- a/core/lastix/core/result.hpp
+++ b/core/lastix/core/result.hpp
@@ -1,0 +1,199 @@
+#pragma once
+
+#include "lastix/core/diagnostics.cpp"
+#include "lastix/core/option.hpp"
+
+#include <variant>
+#include <utility>
+
+namespace lx::core {
+
+    namespace impl {
+
+        template <class T, class Tag> class ResultEnumeration {
+            public:
+                ResultEnumeration() noexcept = default;
+
+                explicit ResultEnumeration(T value) noexcept
+                    : _value(std::move(value)) {
+                }
+
+                auto operator*() & noexcept -> T& {
+                    return _value;
+                }
+
+                auto operator*() const& noexcept -> const T& {
+                    return _value;
+                }
+
+                auto operator*() && noexcept -> T&& {
+                    return std::move(_value);
+                }
+
+            protected:
+                T _value;
+        };
+
+        template <class Tag> class ResultEnumeration<void, Tag> {
+
+            public:
+                ResultEnumeration() = default;
+        };
+
+        struct OkTag {};
+        struct ErrTag {};
+
+        // Handle Ok(Ok(...))
+        template <class U>
+        ResultEnumeration(ResultEnumeration<U, OkTag>)
+            -> ResultEnumeration<ResultEnumeration<U, OkTag>, OkTag>;
+
+        // Handle Err(Err(...))
+        template <class U>
+        ResultEnumeration(ResultEnumeration<U, ErrTag>)
+            -> ResultEnumeration<ResultEnumeration<U, ErrTag>, ErrTag>;
+
+    }; // namespace impl
+
+    template <class T> using Ok = impl::ResultEnumeration<T, impl::OkTag>;
+    template <class E> using Err = impl::ResultEnumeration<E, impl::ErrTag>;
+
+    template <class T, class E> class Result {
+        public:
+            using Value = T;
+            using Error = E;
+            using VariantType = std::variant<Ok<T>, Err<E>>;
+
+            Result(Ok<T> value) noexcept : _variant(std::move(value)) {
+            }
+            Result(Err<E> error) noexcept : _variant(std::move(error)) {
+            }
+
+            /// Accept convertible Ok<U> if U -> T
+            template <class U>
+            requires std::convertible_to<U, T>
+            Result(Ok<U> value) noexcept : _variant(Ok<T>{*std::move(value)}) {
+            }
+
+            /// Accept convertible Err<F> if F -> E
+            template <class F>
+            requires std::convertible_to<F, E>
+            Result(Err<F> error) noexcept
+                : _variant(Err<E>{*std::move(error)}) {
+            }
+
+            [[nodiscard]] auto is_ok() const noexcept -> bool {
+                return std::holds_alternative<Ok<T>>(_variant);
+            }
+
+            [[nodiscard]] auto is_err() const noexcept -> bool {
+                return std::holds_alternative<Err<E>>(_variant);
+            }
+
+            [[nodiscard]] auto ok() const& noexcept -> Option<T> {
+                if (auto* p = std::get_if<Ok<T>>(&_variant)) return Some(**p);
+
+                return None;
+            }
+
+            [[nodiscard]] auto ok() && noexcept -> Option<T> {
+                if (auto* p = std::get_if<Ok<T>>(&_variant))
+                    return Some(std::move(**p));
+
+                return None;
+            }
+
+            [[nodiscard]] auto err() const& noexcept -> Option<E> {
+                if (auto* p = std::get_if<Err<E>>(&_variant)) return Some(**p);
+
+                return None;
+            }
+
+            [[nodiscard]] auto err() && noexcept -> Option<E> {
+                if (auto* p = std::get_if<Err<E>>(&_variant))
+                    return Some(std::move(**p));
+
+                return None;
+            }
+
+            auto unwrap() & noexcept -> T& {
+                if (auto* p = std::get_if<Ok<T>>(&_variant)) return **p;
+
+                panic("Called unwrap() on Err");
+            }
+
+            auto unwrap() const& noexcept -> const T& {
+                if (auto* p = std::get_if<Ok<T>>(&_variant)) return **p;
+
+                panic("Called unwrap() on Err");
+            }
+
+            auto unwrap() && noexcept -> T&& {
+                if (auto* p = std::get_if<Ok<T>>(&_variant))
+                    return std::move(**p);
+
+                panic("Called unwrap() on Err");
+            }
+
+            auto expect(std::string_view msg) & noexcept -> T& {
+                if (auto* p = std::get_if<Ok<T>>(&_variant)) return **p;
+
+                panic(msg);
+            }
+
+            auto expect(std::string_view msg) const& noexcept -> const T& {
+                if (auto* p = std::get_if<Ok<T>>(&_variant)) return **p;
+
+                panic(msg);
+            }
+
+            auto expect(std::string_view msg) && noexcept -> T&& {
+                if (auto* p = std::get_if<Ok<T>>(&_variant))
+                    return std::move(**p);
+
+                panic(msg);
+            }
+
+            auto unwrap_err() & noexcept -> E& {
+                if (auto* p = std::get_if<Err<E>>(&_variant)) return **p;
+
+                panic("Called unwrap_err() on Ok");
+            }
+
+            auto unwrap_err() const& noexcept -> const E& {
+                if (auto* p = std::get_if<Err<E>>(&_variant)) return **p;
+
+                panic("Called unwrap_err() on Ok");
+            }
+
+            auto unwrap_err() && noexcept -> E&& {
+                if (auto* p = std::get_if<Err<E>>(&_variant))
+                    return std::move(**p);
+
+                panic("Called unwrap_err() on Ok");
+            }
+
+            auto expect_err(std::string_view msg) & noexcept -> E& {
+                if (auto* p = std::get_if<Err<E>>(&_variant)) return **p;
+
+                panic(msg);
+            }
+
+            auto expect_err(std::string_view msg) const& noexcept -> const E& {
+                if (auto* p = std::get_if<Err<E>>(&_variant)) return **p;
+
+                panic(msg);
+            }
+
+            auto expect_err(std::string_view msg) && noexcept -> E&& {
+                if (auto* p = std::get_if<Err<E>>(&_variant))
+                    return std::move(**p);
+
+                panic(msg);
+            }
+
+        private:
+            VariantType _variant;
+    };
+
+}; // namespace lx::core

--- a/examples/core/CMakeLists.txt
+++ b/examples/core/CMakeLists.txt
@@ -7,3 +7,13 @@ target_link_libraries(
     example-core-box PRIVATE
     lastix::core
 )
+
+lastix_add_executable(
+    example-core-option
+    "option.cpp"
+)
+
+target_link_libraries(
+    example-core-option PRIVATE
+    lastix::core
+)

--- a/examples/core/CMakeLists.txt
+++ b/examples/core/CMakeLists.txt
@@ -17,3 +17,13 @@ target_link_libraries(
     example-core-option PRIVATE
     lastix::core
 )
+
+lastix_add_executable(
+    example-core-result
+    "result.cpp"
+)
+
+target_link_libraries(
+    example-core-result PRIVATE
+    lastix::core
+)

--- a/examples/core/option.cpp
+++ b/examples/core/option.cpp
@@ -1,0 +1,65 @@
+#include "lastix/core/option.hpp"
+#include "lastix/core/number.hpp"
+
+#include <string>
+#include <print>
+
+using namespace lx::core;
+
+struct MyStruct {
+        i32 x;
+        std::string name;
+
+        MyStruct(i32 value, std::string n) : x(value), name(std::move(n)) {
+            std::println("MyStruct constructed (x = {}, name = {})", x, name);
+        }
+
+        ~MyStruct() {
+            std::println("MyStruct destroyed (x = {}, name = {})", x, name);
+        }
+
+        auto greet() const -> void {
+            std::println("Hello, my name is {} and x = {}", name, x);
+        }
+};
+
+auto main() -> i32 {
+    // Construct Some and None
+    Option<MyStruct> o1 = Some(MyStruct{42, "Alice"});
+    Option<MyStruct> o2 = None;
+
+    std::println("o1 is_some? {}", o1.is_some());
+    std::println("o2 is_none? {}", o2.is_none());
+
+    // Access with unwrap()
+    o1.unwrap().greet();
+
+    // Uncommenting the following line will abort the program
+    // o2.expect("o2 should not be None");
+
+    // Move unwrap
+    Option<std::string> name_opt = Some(std::string("Bob"));
+    std::string name = std::move(name_opt).unwrap();
+    std::println("Got name: {}", name);
+
+    // Copy construction
+    Option<i32> v1 = Some(1337);
+    Option<i32> v2 = v1; // copies underlying optional
+    std::println("v1.unwrap() = {}, v2.unwrap() = {}", v1.unwrap(),
+                 v2.unwrap());
+
+    // Reassignment
+    Option<i32> v3 = None;
+    v3 = Some(99);
+    std::println("v3 after assignment: {}", v3.unwrap());
+
+    // Typical chaining pattern: Option<Option<T>>
+    Option<Option<i32>> nested = Some(Some(7));
+    std::println("nested.unwrap().unwrap() = {}", nested.unwrap().unwrap());
+
+    // Safe conditional
+    Option<i32> maybe = Some(5);
+    if (maybe.is_some()) { std::println("maybe holds {}", maybe.unwrap()); }
+
+    return 0;
+}

--- a/examples/core/result.cpp
+++ b/examples/core/result.cpp
@@ -1,0 +1,42 @@
+#include "lastix/core/result.hpp"
+#include "lastix/core/number.hpp"
+
+using namespace lx::core;
+
+// Result<T, E> currently does not support T or E being void
+struct Empty {};
+
+static auto foo() -> Result<i32, std::string> {
+
+    return Ok(-100);
+}
+
+static auto bar() -> Result<i32, std::string> {
+
+    auto x = foo().expect("Ok() is expected");
+
+    if (x > 0) return Ok(x);
+    else return Err("x > 0 is expected");
+}
+
+static auto baz() -> Result<Empty, i32> {
+
+    auto val = bar();
+
+    if (val.is_ok()) {
+        std::println("bar() succeeded: {}", val.ok().unwrap());
+        return Ok(Empty());
+    }
+
+    auto err = val.unwrap_err();
+    std::println("bar() failed: {}", err);
+
+    return Err(-1);
+}
+
+auto main() -> i32 {
+
+    auto res = baz();
+
+    return res.is_ok() ? 0 : res.unwrap_err();
+}


### PR DESCRIPTION
Add rust-like `Option<T>` and `Result<T>`. They mostly wrap their standard counterparts while providing more explicit API