### PR TITLE
Allow void in result, add result tests, comparison operators

### DIFF
--- a/examples/core/result.cpp
+++ b/examples/core/result.cpp
@@ -6,9 +6,6 @@
 
 using namespace lx::core;
 
-// Result<T, E> currently does not support T or E being void
-struct Empty {};
-
 static auto foo() -> Result<i32, std::string> {
 
     return Ok(-100);
@@ -22,13 +19,13 @@ static auto bar() -> Result<i32, std::string> {
     else return Err("x > 0 is expected");
 }
 
-static auto baz() -> Result<Empty, i32> {
+static auto baz() -> Result<void, i32> {
 
     auto val = bar();
 
     if (val.is_ok()) {
         std::println("bar() succeeded: {}", val.ok().unwrap());
-        return Ok(Empty());
+        return Ok();
     }
 
     auto err = val.unwrap_err();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
     "core/box.cpp"
     "core/memory_helpers.cpp"
     "core/memory_helpers.hpp"
+    "core/result.cpp"
 )
 
 target_compile_options(lastix-tests PRIVATE

--- a/tests/core/result.cpp
+++ b/tests/core/result.cpp
@@ -1,0 +1,53 @@
+#include "catch2/catch_test_macros.hpp"
+#include "lastix/core/result.hpp"
+#include "lastix/core/number.hpp"
+
+#include <string>
+
+using namespace lx::core;
+
+TEST_CASE("Result basic Ok construction", "[lx::core::Result]") {
+    Result<i32, void> r = Ok(42);
+    REQUIRE(r.is_ok());
+    REQUIRE(!r.is_err());
+    REQUIRE(r.unwrap() == 42);
+    REQUIRE(r.ok().unwrap() == 42);
+    REQUIRE(r.err() == None);
+}
+
+TEST_CASE("Result basic Err construction", "[lx::core::Result]") {
+    Result<void, std::string> r = Err("failure");
+    REQUIRE(!r.is_ok());
+    REQUIRE(r.is_err());
+    REQUIRE(r.unwrap_err() == "failure");
+    REQUIRE(r.err().unwrap() == "failure");
+    REQUIRE(r.ok() == None);
+}
+
+TEST_CASE("Result void Ok", "[lx::core::Result]") {
+    Result<void, std::string> r = Ok();
+    REQUIRE(r.is_ok());
+    REQUIRE(!r.is_err());
+}
+
+TEST_CASE("Result copy", "[lx::core::Result]") {
+    Result<i32, std::string> r0 = Ok(10);
+    Result<i32, std::string> r1 = Err("failure");
+
+    auto c0 = r0;
+    auto c1 = r1;
+
+    REQUIRE(c0.is_ok());
+    REQUIRE(c1.is_err());
+    REQUIRE(c0 == r0);
+    REQUIRE(c1 == r1);
+    REQUIRE(c0.unwrap() == 10);
+    REQUIRE(c1.unwrap_err() == "failure");
+}
+
+TEST_CASE("Result move", "[lx::core::Result]") {
+    Result<i32, std::string> r0 = Ok(10);
+    auto c0 = std::move(r0);
+    REQUIRE(c0.is_ok());
+    REQUIRE(c0.unwrap() == 10);
+}


### PR DESCRIPTION
- Allow void in `Result<T, E>`, both success and error values are supported
- Add proper tests for `Result<T, E>`
- Allow comparing 2 instances of `Result<T, E>`