### PR TITLE
add From trait. This allows to do custom conversions between any types

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,6 +10,7 @@ lastix_add_library(
     "lastix/core/option.hpp"
     "lastix/core/result.hpp"
     "lastix/trait/sync.hpp"
+    "lastix/trait/from.hpp"
 )
 
 target_include_directories(

--- a/core/lastix/trait/from.hpp
+++ b/core/lastix/trait/from.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <concepts>
+
+namespace lx::trait {
+
+    namespace impl {
+
+        template <class...> inline constexpr bool always_false = false;
+    };
+
+    template <class FromType, class ToType> struct FromImpl;
+
+    template <class FromType, class ToType>
+    concept From = requires(FromType t) {
+        { FromImpl<FromType, ToType>::from(t) } -> std::convertible_to<ToType>;
+    };
+
+    static constexpr auto x = From<int, double>;
+
+}; // namespace lx::trait


### PR DESCRIPTION
Add From trait. This allows to do custom conversions between any types included enums, which is not possible in c++ with operators